### PR TITLE
Fixed problem to run frontend container

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -29,7 +29,7 @@
       },
       "devDependencies": {
         "@angular-devkit/build-angular": "^18.2.4",
-        "@angular/cli": "^18.2.4",
+        "@angular/cli": "^18.2.19",
         "@angular/compiler-cli": "^18.2.0",
         "@types/express": "^4.17.17",
         "@types/jasmine": "~5.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^18.2.4",
-    "@angular/cli": "^18.2.4",
+    "@angular/cli": "^18.2.19",
     "@angular/compiler-cli": "^18.2.0",
     "@types/express": "^4.17.17",
     "@types/jasmine": "~5.1.0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,10 @@ services:
     working_dir: /app
     volumes:
       - ./app:/app
+      - /app/node_modules
     ports:
       - 4200:4200
-    command: sh -c "chown -R node:node /app && rm -rf /app/node_modules /app/.angular && npm install && npm run docker-start"
+    command: sh -c "npm install && npm run docker-start"
     depends_on:
       - backend
     container_name: ETS_FRONTEND


### PR DESCRIPTION
Para solucionar los problemas descritos se han tomado las siguientes soluciones:

Cambiar el servicio del docker-compose.yml de:
_command: sh -c "chown -R node:node /app && rm -rf /app/node_modules /app/.angular && npm install && npm run docker-start"_

a:
_command: sh -c "npm install && npm run docker-start"_

Se ha añadido ng como dependencia de desarrollo y para evitar conflictos con el host windows se ha creado un volumen para el node_modules del contenedor.

